### PR TITLE
BUG - Unable parse options

### DIFF
--- a/lib/wicked_pdf.rb
+++ b/lib/wicked_pdf.rb
@@ -162,8 +162,8 @@ class WickedPdf
       scale: options[:scale] || 1.0,
       displayHeaderFooter: options[:displayHeaderFooter] || false,
       pageRanges: options[:pageRanges] || '',
-      headerTemplate: options[:header] && options[:header][:html] ? options[:header][:html][:string] : nil,
-      footerTemplate: options[:footer] && options[:footer][:html] ? options[:footer][:html][:string] : nil
+      headerTemplate: options[:header] && options[:header][:html] ? options[:header][:html][:string] : '',
+      footerTemplate: options[:footer] && options[:footer][:html] ? options[:footer][:html][:string] : ''
     }
 
     data = @client.send_cmd 'Page.printToPDF', pdf_options


### PR DESCRIPTION
When the options has nil value.`chrome_remote` will give a error as:
```
{"id"=>4,
 "error"=>
  {"code"=>-32602,
   "message"=>"Invalid parameters",
   "data"=>
    "Failed to deserialize params.headerTemplate - BINDINGS: string value expected at position 205"}}
```
So I need assign blank string instead of nil
Two options have the problem:
1. headerTemplate
2. footerTemplate